### PR TITLE
Add documentation about building on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,3 @@ make package FINALPACKAGE=1 STRIP=0
 
 ## License
 This project is licensed under the [Boost Software License 1.0](./LICENSE). Additionally, this project also uses code from [LiveContainer](https://github.com/khanhduytran0/LiveContainer). View the [NOTICE.md](./NOTICE.md) for more details.
-
-## Footnotes
-It may be possible to run Theos on a non-GNU Linux system, however this is poorly documented and is not recommended.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you have any further questions, or need help, be sure to join [our Discord se
 ## Building / Development
 
 To build this project, you must have the following prerequisites installed:
-- [Theos](https://theos.dev/docs/) [WSL for Windows]
+- [Theos](https://theos.dev/docs/) [WSL for Windows and GNU/Linux]
 - [make](https://formulae.brew.sh/formula/make) [Mac OS only]
 
 After installing these, you can compile the project by running:
@@ -39,3 +39,6 @@ make package FINALPACKAGE=1 STRIP=0
 
 ## License
 This project is licensed under the [Boost Software License 1.0](./LICENSE). Additionally, this project also uses code from [LiveContainer](https://github.com/khanhduytran0/LiveContainer). View the [NOTICE.md](./NOTICE.md) for more details.
+
+## Footnotes
+It may be possible to run Theos on a non-GNU Linux system, however this is poorly documented and is not recommended.


### PR DESCRIPTION
## Build documentation for Linux is important, so I have made this MR to rectify this.

As stated by Firéè, Theos is required on Linux to build.

I have found no documentation online about running Theos on a non-GNU Linux system (as this is not a common setup), so I have specified GNU/Linux.

Maintainers, if you do not wish to add the footnote, **feel free** to remove it. I have allowed edits by maintainers.