### PR TITLE
reorganise INSTALL.MD

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,12 +10,15 @@ This page **will help you install Geode on your iDevice**. This page exists beca
 
 To get started, choose an installation guide for your iOS version.
 
-[iOS 16.7 RC, iOS 17.0 and Below (TrollStore / Jailbreak)](/OLD-IOS-INSTALL.md) \
-[iOS 17.4+ (SideStore)](/MODERN-IOS-INSTALL.md) \
-[iOS 26 (JIT-Less)](/JITLESS-INSTALL-GUIDE.md) \
+[iOS 16.7 RC, iOS 17.0 and Below (TrollStore / Jailbreak)](/OLD-IOS-INSTALL.md)
+
+[iOS 17.4+ (SideStore)](/MODERN-IOS-INSTALL.md)
+
+[iOS 26 (JIT-Less)](/JITLESS-INSTALL-GUIDE.md)
+
 [LiveContainer](/LIVECONTAINER-INSTALL-GUIDE.md)
 
 > [!TIP]
 > If you **don't know which iOS version you're on**, follow [this page from Apple](https://support.apple.com/en-us/109065) to check your iOS version.\
 > \
-> If you don't have a PC, and are above iOS 17.4+, follow the [JIT-less guide](/JITLESS-INSTALL-GUIDE.md). This guide can be used without spending money, as long as you have a PC and use SideStore.
+> If you **don't have a PC**, **are on iOS 17.4 or later (especially iOS 26)**, and are **willing to spend money on an Apple developer certificate**, you can follow the [JIT-less](/JITLESS-INSTALL-GUIDE.md) guide to use Geode **without a PC**. If you **have a PC**, as long as **you're not on iOS 26**, you can use the [SideStore](/MODERN-IOS-INSTALL.md) method. If **you are on iOS 26 and have a PC**, follow the [SideStore](/MODERN-IOS-INSTALL.md) guide but **instead of setting up StikDebug**, follow the [JIT-less](/JITLESS-INSTALL-GUIDE.md) guide and **import the SideStore certificate** (the steps to import the certificate are **available in the JIT-less guide**) and make sure that you have **the versions of SideStore listed in the JIT-less guide**.


### PR DESCRIPTION
remove individual warning and tip sections per statement; only have them in one big block
move tip sections under guides links rather than above it
remove conflicting statement about whether you need money or not in order to follow the JIT-less guide