### PR TITLE
Added information table on installation guides

### DIFF
--- a/ENTERPRISE-INSTALL-GUIDE.md
+++ b/ENTERPRISE-INSTALL-GUIDE.md
@@ -10,6 +10,10 @@
 > This guide will not teach you how to go about obtaining such certificates. These certificates ("free certificates") violate [Apple's Terms of Service](https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#ADPLA5), and may get your iDevice blacklisted. As such, this guide is only for educational purposes, given the consequences: Use at your own risk.
 > If you are fine with this, and acknowledge the warning, you can proceed to follow this guide.
 
+| Supported on | Requires Computer? | Mod Compatibility | Price |
+|--------------|--------------------|-------------------|-------|
+| iOS 14.0 and adove | No | *Medium* | Free |
+
 This tutorial is for people who cannot afford to purchase a Developer Certificate, and do not have a computer, but wish to use Geode.
 
 ## Prerequisites

--- a/JITLESS-INSTALL-GUIDE.md
+++ b/JITLESS-INSTALL-GUIDE.md
@@ -2,6 +2,10 @@
 > [!WARNING]
 > This guide will not work for Enterprise Certificates ("free certificates"), and certificates without the entitlement `get-task-allow`. A developer certficate (or one from SideStore) is required for you to follow this guide. If you wish to use certificates without entitlements, follow the [Enterprise Certificate](./ENTERPRISE-INSTALL-GUIDE.md) guide instead.
 
+| Supported on | Requires Computer? | Mod Compatibility | Price |
+|--------------|--------------------|-------------------|-------|
+| iOS 14.0 and adove (mainly for iOS 26)| Depends (SideStore method requires a computer) | *Medium* | Depends (Developer Certificate method is *not* free) |
+
 This tutorial is mainly for iOS 26, as Apple broke enabling JIT on iOS 26, but it should theoretically work for any iOS version. This guide is also for those that wish to use Geode, but don't have a computer.
 
 # Prerequisites

--- a/LIVECONTAINER-INSTALL-GUIDE.md
+++ b/LIVECONTAINER-INSTALL-GUIDE.md
@@ -1,4 +1,9 @@
 # Installation Guide (LiveContainer)
+
+| Supported on | Requires Computer? | Mod Compatibility | Price |
+|--------------|--------------------|-------------------|-------|
+| iOS 14.0 and adove | Yes | *Medium* to *High* (*Medium* on JIT-Less) | Free |
+
 This tutorial is for people that use LiveContainer to bypass Apple's 3 active app and 10 app ID limit.
 
 > [!TIP]

--- a/MODERN-IOS-INSTALL.md
+++ b/MODERN-IOS-INSTALL.md
@@ -5,6 +5,10 @@
 > \
 > This guide assumes you will be installing SideStore. Using enterprise certificates to install SideStore **will not work**, as the usage of a PC is required to sideload SideStore.
 
+| Supported on | Requires Computer? | Mod Compatibility | Price |
+|--------------|--------------------|-------------------|-------|
+| iOS 16 to 17.4 and adove | Yes | *Medium* to *High* (*Medium* on JIT-Less) | Free |
+
 ## Prerequisites
 - PC (Windows, Mac, Linux)
 - Apple ID (Secondary / Throwaway Recommended)

--- a/OLD-IOS-INSTALL.md
+++ b/OLD-IOS-INSTALL.md
@@ -1,5 +1,9 @@
 # Installation Guide (TrollStore / Jailbreak)
 
+| Supported on | Requires Computer? | Mod Compatibility | Price |
+|--------------|--------------------|-------------------|-------|
+| iOS 14.0 to 17.0 (Excluding iOS 16.7.x and 17.0.x) | On iOS 17.0 | *High* | Free |
+
 This guide is for devices that are compatible with TrollStore (and optionally a jailbreak)
 
 > [!TIP]


### PR DESCRIPTION
On `INSTALL.md` there is a table that lists all of the guides for installing Geode on iOS, alongside what iOS version they're compatible with, whether a computer is required, etc. All I did is I took the information from there and I added it at the beginning of all of the linked installation guides as well.

I just added it since imo it's cool, it's clean, and it can be more convenient if you somehow forgot the information from `INSTALL.md` from the guide you're currently in