### PR TITLE
Update MODERN-IOS-INSTALL.md

### DIFF
--- a/MODERN-IOS-INSTALL.md
+++ b/MODERN-IOS-INSTALL.md
@@ -7,7 +7,7 @@
 
 | Supported on | Requires Computer? | Mod Compatibility | Price |
 |--------------|--------------------|-------------------|-------|
-| iOS 14 and above | Yes | *Medium* to *High* (*Medium* on JIT-Less) | Free |
+| iOS 15 and above | Yes | *Medium* to *High* (*Medium* on JIT-Less) | Free |
 
 ## Prerequisites
 - PC (Windows, Mac, Linux)


### PR DESCRIPTION
Removed iOS 16 as the minimum requirement because iOS 14 is also compatible with SideStore

Added temporary steps to install SideJITServer for iOS 17.0.1 - 17.3 (will get changed)