### PR TITLE
Fixed the Jitless guide error in enterprise certs guide

### DIFF
--- a/ENTERPRISE-INSTALL-GUIDE.md
+++ b/ENTERPRISE-INSTALL-GUIDE.md
@@ -1,6 +1,6 @@
 # Installation Guide (Free aka Enterprise Certificates)
 > [!IMPORTANT]
-> While this guide will teach you how to enable and use certificates without entitlements on Geode, it is still recommended to buy a Developer Certificate if you can, and follow the [JIT-Less guide](./JITLESS-INSTALL-GUIDE.md), as this method is not endorsed or recommended.
+> While this guide will teach you how to enable and use certificates without entitlements on Geode, it is still recommended to buy a Developer Certificate if you can, and follow the [Apple Developer Certificates guide](./APPLE-DEV-CERT-INSTALL-GUIDE.md), as this method is not endorsed or recommended.
 > This is because this method is time consuming, tedious, and slow for using Geode, as it will require you to install a patched Geometry Dash ("Geode Helper") each time you want to install a mod, update a mod, enable a mod, disable a mod, update Geode, and launch in safe mode.
 
 > [!CAUTION]


### PR DESCRIPTION
Replaced the old JIT-less guide in the enterprise certs guide to now redirect users to the apple dev certs guide